### PR TITLE
Allow legacy profile to have space in stack

### DIFF
--- a/cmd/pprofutils/version.go
+++ b/cmd/pprofutils/version.go
@@ -2,4 +2,4 @@
 
 package main
 
-var version = "v2.0.2-7-g96ce852"
+var version = "v2.0.2-9-gf32606d"

--- a/internal/legacy/text.go
+++ b/internal/legacy/text.go
@@ -60,9 +60,9 @@ func (c Text) Convert(text io.Reader) (*profile.Profile, error) {
 			continue
 		}
 
-		parts := strings.Split(line, " ")
-		if len(parts) != len(p.SampleType)+1 {
-			return nil, fmt.Errorf("bad line: %d: %q", n, line)
+		parts, err := splitLastN(line, len(p.SampleType))
+		if err != nil {
+			return nil, err
 		}
 
 		stack := strings.Split(parts[0], ";")
@@ -110,4 +110,26 @@ func looksLikeHeader(line string) bool {
 		}
 	}
 	return true
+}
+
+// split line from bottom up given expected number of spaces
+func splitLastN(line string, n int) ([]string, error) {
+	parts := make([]string, n+1)
+
+	for i, j := len(line)-1, len(line); i >= 0 && n > 0; i-- {
+		if line[i] == ' ' {
+			parts[n] = line[i+1 : j]
+			j = i
+			n--
+		}
+		if n == 0 {
+			parts[n] = line[:i]
+		}
+	}
+
+	if n > 0 {
+		return nil, fmt.Errorf("bad line: %q", line)
+	}
+
+	return parts, nil
 }

--- a/internal/legacy/text_test.go
+++ b/internal/legacy/text_test.go
@@ -2,6 +2,8 @@ package legacy
 
 import (
 	"bytes"
+	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -52,4 +54,34 @@ main;foo;bar 3 30000000
 		is.NoErr(Protobuf{SampleTypes: true}.Convert(proto, &textOut))
 		is.Equal(textIn+"\n", textOut.String())
 	})
+}
+
+func TestSplitLastN(t *testing.T) {
+	for _, tc := range []struct {
+		line        string
+		n           int
+		expected    []string
+		expectedErr bool
+	}{
+
+		{"main;foo 5", 1, []string{"main;foo", "5"}, false},
+		{"main;foo 5", 2, nil, true},
+		{"main;foo 5 10", 2, []string{"main;foo", "5", "10"}, false},
+		{"main;foo;foo bar 5", 1, []string{"main;foo;foo bar", "5"}, false},
+		{"main;foo;foo bar 5 10", 2, []string{"main;foo;foo bar", "5", "10"}, false},
+	} {
+
+		t.Run(fmt.Sprintf("line=%q, n=%d", tc.line, tc.n), func(t *testing.T) {
+			res, err := splitLastN(tc.line, tc.n)
+			if tc.expectedErr && err == nil {
+				t.Fatalf("line=%q, n=%d, expected err but passed", tc.line, tc.n)
+			}
+			if !tc.expectedErr && err != nil {
+				t.Fatalf("line=%q, n=%d, unexpected err: %v", tc.line, tc.n, err)
+			}
+			if !reflect.DeepEqual(tc.expected, res) {
+				t.Fatalf("expected=%v, got=%v", tc.expected, res)
+			}
+		})
+	}
 }


### PR DESCRIPTION
First of all, thanks for the tool. It's awesome !

Now to the PR :) In some of our apps, we generate a folded text that has space in it. For example:

```
doing_something;JIT Compiler 1
```

This breaks current legacy converter because it's using `string.Split`. The current PR changes it so that we parse the line with the number of expected whitespace from last, with number of whitespace equals to len length of `SampleType`.

This solves the problem for us, and probably solves https://github.com/felixge/pprofutils/issues/3 as well.