### PR TITLE
Support outputting line numbers in folded format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ The input and output file default to "-" which means stdin or stdout.
 #### Use folded utility via cli
 
 ```
-pprofutils folded [-headers] <input file> <output file>
+pprofutils folded [-headers] [-line_numbers] <input file> <output file>
 
 FLAGS:
-  -headers=false Add header column for each sample type
+  -headers=false       Add header column for each sample type
+  -line_numbers=false  Add line numbers to the name of each frame
 ```
 
 #### Use folded utility via web service

--- a/internal/legacy/protobuf_test.go
+++ b/internal/legacy/protobuf_test.go
@@ -53,4 +53,24 @@ main.run.func1;main.threadKind.Run;main.goGo0;main.goHog;runtime.asyncPreempt 1
 `) + "\n"
 		is.Equal(out.String(), want)
 	})
+
+	t.Run("line numbers in output", func(t *testing.T) {
+		is := is.New(t)
+		data, err := ioutil.ReadFile(filepath.Join("test-fixtures", "pprof.lines.pb.gz"))
+		is.NoErr(err)
+
+		proto, err := profile.Parse(bytes.NewReader(data))
+		is.NoErr(err)
+
+		out := bytes.Buffer{}
+		is.NoErr(Protobuf{LineNumbers: true}.Convert(proto, &out))
+		want := strings.TrimSpace(`
+main.run.func1:62;main.threadKind.Run:96;main.goGo1:106;main.goHog:128 85
+main.run.func1:62;main.threadKind.Run:96;main.goGo2:109;main.goHog:128 78
+main.run.func1:62;main.threadKind.Run:96;main.goGo3:112;main.goHog:128 72
+main.run.func1:62;main.threadKind.Run:96;main.goGo0:103;main.goHog:128 72
+main.run.func1:62;main.threadKind.Run:96;main.goGo0:103;main.goHog:128;runtime.asyncPreempt:8 1
+`) + "\n"
+		is.Equal(out.String(), want)
+	})
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -96,7 +96,8 @@ TODO: Support memory profiles.
 	{
 		Name: "folded",
 		Flags: map[string]UtilFlag{
-			"headers": {false, "Add header column for each sample type"},
+			"headers":      {false, "Add header column for each sample type"},
+			"line_numbers": {false, "Add line numbers to the name of each frame"},
 		},
 		ShortUsage: "[-headers] <input file> <output file>",
 		ShortHelp:  "Converts pprof to Brendan Gregg's folded text format and vice versa",
@@ -110,9 +111,10 @@ format is automatically detected and used to determine the output format.
 		},
 		Execute: func(ctx context.Context, a *UtilArgs) error {
 			return (&utils.Folded{
-				Input:   a.Inputs[0],
-				Output:  a.Output,
-				Headers: a.Flags["headers"].(bool),
+				Input:       a.Inputs[0],
+				Output:      a.Output,
+				Headers:     a.Flags["headers"].(bool),
+				LineNumbers: a.Flags["line_numbers"].(bool),
 			}).Execute(ctx)
 		},
 	},

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -99,7 +99,7 @@ TODO: Support memory profiles.
 			"headers":      {false, "Add header column for each sample type"},
 			"line_numbers": {false, "Add line numbers to the name of each frame"},
 		},
-		ShortUsage: "[-headers] <input file> <output file>",
+		ShortUsage: "[-headers] [-line_numbers] <input file> <output file>",
 		ShortHelp:  "Converts pprof to Brendan Gregg's folded text format and vice versa",
 		LongHelp: strings.TrimSpace(`
 Converts pprof to Brendan Gregg's folded text format and vice versa. The input

--- a/utils/folded.go
+++ b/utils/folded.go
@@ -10,9 +10,10 @@ import (
 )
 
 type Folded struct {
-	Input   []byte
-	Output  io.Writer
-	Headers bool
+	Input       []byte
+	Output      io.Writer
+	Headers     bool
+	LineNumbers bool
 }
 
 func (f *Folded) Execute(ctx context.Context) error {
@@ -20,6 +21,7 @@ func (f *Folded) Execute(ctx context.Context) error {
 	if err == nil {
 		p := legacy.Protobuf{
 			SampleTypes: f.Headers,
+			LineNumbers: f.LineNumbers,
 		}
 		return p.Convert(prof, f.Output)
 	}


### PR DESCRIPTION
Hey Felix, thanks for the nice toolset here :wave:

I've recently needed to do line-granularity deduplication work between 2 profiles and supporting line numbers on the folded output was extremely helpful. I imagine other people might want it as well and, as such, thought having a flag for it would be a good improvement 😄 

Proof that this works (apart from included unit test):

```
❯ pprofutils folded -line_numbers=true go.alloc.pb | head -n 3
github.com/DataDog/dd-go/trace/intake/common.(*Resolver).resolveStats.func1:547;github.com/DataDog/dd-go/trace/agent/model.TagSet.Key:74;github.com/DataDog/dd-go/trace/agent/model.Tag.String:20 44631378
github.com/DataDog/dd-go/trace/intake/common.(*Resolver).resolveStats.func1:494;github.com/DataDog/dd-go/trace/intake/common.(*Resolver).resolveTagSet:422;github.com/DataDog/dd-go/trace/agent/model.SplitTag:26;strings.SplitN:282;strings.genSplit:256 27804496
github.com/DataDog/dd-go/trace/intake/common.(*Resolver).resolveStats.func1:507;github.com/DataDog/dd-go/trace/agent/model.SplitTag:26;strings.SplitN:282;strings.genSplit:256 27165501

❯ pprofutils folded -line_numbers=false go.alloc.pb | head -n 3
github.com/DataDog/dd-go/trace/intake/common.(*Resolver).resolveStats.func1;github.com/DataDog/dd-go/trace/agent/model.TagSet.Key;github.com/DataDog/dd-go/trace/agent/model.Tag.String 60852033
github.com/DataDog/dd-go/trace/intake/common.(*Resolver).resolveStats.func1;github.com/DataDog/dd-go/trace/intake/common.(*Resolver).resolveTagSet;github.com/DataDog/dd-go/trace/agent/model.SplitTag;strings.SplitN;strings.genSplit 41354477
github.com/DataDog/dd-go/trace/intake/common.(*Resolver).resolveStats.func1;github.com/DataDog/dd-go/trace/agent/model.SplitTag;strings.SplitN;strings.genSplit 39797950
```

And that extra granularity does not somehow lead to wrong values:

```
❯ pprofutils folded -line_numbers=false go.alloc.pb | awk '{ s += $2 } END { print s }' 
2363251702

❯ pprofutils folded -line_numbers=true go.alloc.pb | awk '{ s += $2 } END { print s }'
2363251702
```